### PR TITLE
Update the node-sass-magic-importer package to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ if there's no file path specified after the `dat-design` module name (like above
 @import "~dat-design/responsive/breakpoints.scss"
 ```
 
-node-sass-magic-importer offers lots of other options in addition to these as well. do note that the magic importer is still under active development.
+node-sass-magic-importer offers lots of other options in addition to these as well.
 
 ### How To Use Dat (S)CSS in Your Project
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "glob": "^7.1.1",
     "handlebars": "^4.0.5",
     "node-sass": "^3.7.0",
-    "node-sass-magic-importer": "^0.1.4",
+    "node-sass-magic-importer": "^1.1.2",
     "nodemon": "^1.9.2",
     "spritesh": "^1.2.0",
     "svgo": "^0.7.0"


### PR DESCRIPTION
I noticed that you're using a pretty old version of the node-sass-magic-importer module. Version 1.x.x is now very stable and well tested so I recommend you to use the new version instead. I also removed the notice from the readme that the package is still under development.

You can find all informations about the latest features in the [readme](https://github.com/maoberlehner/node-sass-magic-importer/blob/master/README.md)

Your project looks pretty interesting and I'm happy you find my module useful.